### PR TITLE
Rough script to prepare an Octave package

### DIFF
--- a/.github/workflows/octave_pkg.yml
+++ b/.github/workflows/octave_pkg.yml
@@ -46,7 +46,7 @@ jobs:
           # docker exec oc octave-cli --eval "pkg install struct optim"
 
       - name: Try to install the package (should fail as we need Octave >= 11)
-        run: docker exec oc octave-cli --eval "cd chebfun/octave_pkg; pkg install chebfun-*.tar.gz"
+        run: docker exec oc octave-cli --eval "cd chebfun/octave_pkg; try, pkg install chebfun-*.tar.gz, exit(1), catch err, disp(err.message), end"
 
       - name: Stop container
         run: |

--- a/.github/workflows/octave_pkg.yml
+++ b/.github/workflows/octave_pkg.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: FSFAP
+# Copyright 2025 The Chebfun Developers
+# See http://www.chebfun.org/ for Chebfun information.
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+name: Octave packaging
+
+on:
+  push:
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  octave-pkg:
+    name: Octave package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Assemble Octave pkg
+        run: |
+          uname -a
+          pwd
+          cd octave_pkg
+          ./make_oct_pkg.sh
+          ls
+          md5sum chebfun-*.tar.gz
+
+      - name: Container setup
+        run: |
+          uname -a
+          docker pull docker.io/gnuoctave/octave:10.2.0
+          docker run --name=oc --detach --init \
+            --volume=$PWD:/workdir/chebfun:rw \
+            gnuoctave/octave:10.2.0 sleep inf
+          # FIXME: workaround "fatal: unsafe repository" error
+          # For more details, see https://stackoverflow.com/q/71901632
+          # and https://github.com/actions/checkout/issues/760
+          docker exec oc git config --global --add safe.directory /workdir/chebfun
+          # docker exec oc octave-cli --eval "pkg install struct optim"
+
+      - name: Try to install the package (should fail as we need Octave >= 11)
+        run: docker exec oc octave-cli --eval "cd chebfun/octave_pkg; pkg install chebfun-*.tar.gz"
+
+      - name: Stop container
+        run: |
+          docker stop oc
+          docker rm oc

--- a/octave_pkg/DESCRIPTION
+++ b/octave_pkg/DESCRIPTION
@@ -1,0 +1,14 @@
+Name: chebfun
+Version: 5.7.0+
+Date: 2025-08-09
+Author: The Chebfun Developers
+Maintainer: Colin B. Macdonald <cbm@m.fsf.org>
+Title: Chebfun: numerical computing with functions
+Description: Chebfun is an open-source package for computing with functions
+ to about 15-digit accuracy.  Most Chebfun commands are overloads of
+ familiar Octave/MATLAB commands — for example sum(f) computes an
+ integral, roots(f) finds zeros, and u = L\f solves a differential equation.
+Categories: ApproximationTheory
+Url: https://github.com/cbm755/chebfun
+Depends: octave (>= 11.0)
+License: BSD-3-Clause

--- a/octave_pkg/NEWS
+++ b/octave_pkg/NEWS
@@ -1,0 +1,4 @@
+chebfun 5.7.0+
+==============
+
+  * Experimental Octave package.

--- a/octave_pkg/make_oct_pkg.sh
+++ b/octave_pkg/make_oct_pkg.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Very rough packaging script, many packages have a "Maintainers Makefile"
+# that does a much nicer job.  But this might do for now!
+
+A=chebfun-5.7.0+
+
+rm -rf $A
+mkdir $A
+cp NEWS DESCRIPTION $A
+cp ../LICENSE.txt $A/COPYING
+pushd $A
+mkdir inst
+cp -ra ../../ inst/
+rm -rf inst/.git
+rm -rf inst/.github
+popd
+tar zcvf $A.tar.gz $A
+


### PR DESCRIPTION
How to try this:

```
git clone ...
cd octave_pkg
./make_oct_pkg
```

This will make a file called `chebfun-5.7.0+.tar.gz`.  Open Octave 11 and run `pkg install chebfun-5.7.0+.tar.gz` followed by `pkg load chebfun`.

An example to try:

```
x = chebfun('x')
f = exp(sin(3*x))
plot(f)
fp = diff(f)
r = roots(fp)
hold on
plot(r, f(r), 'rx')
```



There are many warnings showing up: I haven't looked at any of them yet.