### PR TITLE
Use `is_octave` and no need to support ancient versions

### DIFF
--- a/@chebfun/disp.m
+++ b/@chebfun/disp.m
@@ -7,13 +7,9 @@ function disp(f)
 % See http://www.chebfun.org/ for Chebfun information.
 
 % If the 'format loose' setting is enabled, we print additional linebreaks:
-if (exist('OCTAVE_VERSION', 'builtin') )
-    if (compare_versions(OCTAVE_VERSION(), '4.3.0', '>='))
-        [fmt, spacing] = format();
-        loose = strcmp(spacing, 'loose');
-    else
-        loose = eval('! __compactformat__ ()');
-    end
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
 else
     loose = strcmp(get(0, 'FormatSpacing'), 'loose');
 end

--- a/@chebfun/display.m
+++ b/@chebfun/display.m
@@ -13,18 +13,14 @@ function display(X)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-if (exist('OCTAVE_VERSION', 'builtin') )
-    if (compare_versions(OCTAVE_VERSION(), '4.3.0', '>='))
-        [fmt, spacing] = format();
-        loose = strcmp(spacing, 'loose');
-    else
-        loose = eval('! __compactformat__ ()');
-    end
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
 else
-    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
 end
 
-if ( ~ loose )
+if ( compact )
     disp([inputname(1), ' =']);
     disp(X);
 else

--- a/@chebfun2/disp.m
+++ b/@chebfun2/disp.m
@@ -1,12 +1,17 @@
 function disp(F)
 %DISP   Display a CHEBFUN2 to the command line.
-% 
+%
 % See also DISPLAY.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp( get(0, 'FormatSpacing'), 'loose' );
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Get display style and remove trivial empty CHEBFUN2 case. 
 if ( isempty(F) )

--- a/@chebfun2/display.m
+++ b/@chebfun2/display.m
@@ -9,10 +9,17 @@ function display(X)
 %
 % See also DISP.
 
-% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(X);
 else
@@ -23,5 +30,3 @@ else
 end
 
 end
-
-

--- a/@chebfun2v/disp.m
+++ b/@chebfun2v/disp.m
@@ -4,9 +4,14 @@ function disp(F)
 % See also DISPLAY.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
-% See http://www.chebfun.org/ for Chebfun information. 
+% See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp(get(0,'FormatSpacing'),'loose');
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Compact version
 if ( isempty( F ) )

--- a/@chebfun2v/display.m
+++ b/@chebfun2v/display.m
@@ -8,9 +8,16 @@ function display(X)
 %   statement that results in a CHEBFUN2V.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
-% See http://www.chebfun.org/ for Chebfun information. 
+% See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(X);
 else

--- a/@chebfun3/disp.m
+++ b/@chebfun3/disp.m
@@ -1,12 +1,17 @@
 function disp(F)
 %DISP   Display a CHEBFUN3 to the command line.
-% 
+%
 % See also CHEBFUN3/DISPLAY.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp( get(0, 'FormatSpacing'), 'loose');
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Get display style and remove trivial empty CHEBFUN3 case.
 if ( isempty(F) )

--- a/@chebfun3/display.m
+++ b/@chebfun3/display.m
@@ -12,7 +12,14 @@ function display(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(F);
 else

--- a/@chebfun3t/display.m
+++ b/@chebfun3t/display.m
@@ -4,7 +4,14 @@ function display(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
+
+if ( ~ loose )
 	disp([inputname(1), ' =']);
 else
 	disp(' ');
@@ -12,7 +19,6 @@ else
 	disp(' ');
 end
 
-loose = strcmp( get(0, 'FormatSpacing'), 'loose');
 
 % Get display style and remove trivial empty CHEBFUN3 case.
 if ( isempty(F) )

--- a/@chebfun3v/disp.m
+++ b/@chebfun3v/disp.m
@@ -6,7 +6,12 @@ function disp(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Compact version
 if ( isempty(F) )

--- a/@chebfun3v/display.m
+++ b/@chebfun3v/display.m
@@ -12,7 +12,14 @@ function display(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(F);
 else


### PR DESCRIPTION
Minor edit for a smaller change to disp/display.

@kolmanthomas, merge if you're happy with this.