### PR TITLE
More Chebop changes

### DIFF
--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -291,7 +291,8 @@ classdef chebop
             p = cheboppref();
             
             % Should anonymous functions automatically be vectorized?
-            N.vectorize = p.vectorize;
+            % N.vectorize = p.vectorize;
+            N.vectorize = false;
             
             if ( nargin == 0 )
                 return

--- a/@domain/cumsum.m
+++ b/@domain/cumsum.m
@@ -1,0 +1,10 @@
+function J = cumsum(d, varargin)
+%CUMSUM    Indefinite integration operator.
+%   This function is deprecated. Use OPERATORBLOCK.CUMSUM.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+J = linop( operatorBlock.cumsum(double(d), varargin{:}) );
+
+end

--- a/@domain/diag.m
+++ b/@domain/diag.m
@@ -1,0 +1,10 @@
+function F = diag(f, d)
+%DIAG      Pointwise multiplication operator.
+%   This function is deprecated. Use OPERATORBLOCK.MULT.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+F = linop( operatorBlock.mult(f, double(d)) );
+
+end

--- a/@domain/diff.m
+++ b/@domain/diff.m
@@ -1,0 +1,10 @@
+function F = diff(d, varargin)
+%DIFF      Differentiation operator.
+%   This function is deprecated. Use OPERATORBLOCK.DIFF.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+F = linop( operatorBlock.diff(double(d), varargin{:}) );
+
+end

--- a/@domain/domain.m
+++ b/@domain/domain.m
@@ -1,0 +1,158 @@
+classdef (InferiorClasses = {?chebfun}) domain
+%DOMAIN   Utility class for CHEBFUN. Mostly for backward compatibility.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% DOMAIN Class Description:
+%
+% DOMAIN inherits from a standard Matlab DOUBLE. A domain object only
+% contains vector for the endpoints and breakpoints of the interval it
+% represents. This class is lightly documented, since it is mostly intended
+% for backward compatibility.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS PROPERTIES:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    properties ( Access = public )
+        data
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS CONSTRUCTOR:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    methods ( Access = public, Static = false )
+
+        function obj = domain(varargin)
+            %Constructor for the DOMIAN class.
+            
+            if ((nargin == 1) && isa (varargin{1}, 'domain'))
+                obj = varargin{1};
+                return
+            end
+
+            % Return an empty DOMAIN on null input:
+            if ( nargin == 0 )
+                data = [];
+            else
+                data = horzcat(varargin{:});
+            end
+            
+            % Create the domain:
+            %obj = obj@double(data);
+            obj.data = data;
+            
+        end
+        
+    end     
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS METHODS:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    methods ( Access = public, Static = false )
+        
+        function out = validate(x)
+            dom = x.data;
+            out = true;
+            if ( ~isnumeric(dom) || any(isnan(dom)) )
+                out = false;
+            elseif ( isempty(dom) )
+                return
+            elseif ( size(dom, 1) > 1 || size(dom, 2) < 2 )
+                out = false;
+            elseif ( any(diff(dom) <= 0) )
+                out = false;
+            end
+            if ( out == false && nargout == 0 )
+                error('CHEBFUN:DOMAIN:domain:invalid', ...
+                    'Ends must be a 1xM vector of ordered doubles.');
+            end
+        end
+        
+        function display(dom)
+            disp(dom.data)
+        end
+
+        function out = subsref(d, s)
+            % broken on Octave:
+            %out = subsref@double(d, s);
+            %out = double(out(s));
+            switch s.type
+                case '()'
+                    assert (length(s.subs) == 1)
+                    out = d.data(s.subs{1});
+                otherwise
+                    s
+                    error('not implemented')
+            end
+        end
+
+        function out = numel(d)
+            out = numel(d.data);
+        end
+
+        function [n,m] = size(d)
+            if (nargout == 0 || nargout == 1)
+                n = size(d.data);
+            elseif (nargout == 2)
+                [n, m] = size(d.data);
+            else
+                error('not implemented');
+            end
+        end
+
+        function out = transpose(d)
+            out = domain(d.data.');
+        end
+
+        function out = double(d)
+            out = d.data;
+        end
+
+        function out = feval(s, dom)
+            out = feval(s, dom.data);
+        end
+
+        function [varargout] = setdiff(varargin)
+            for i=1:nargin
+                varargin{i} = double(varargin{i});
+            end
+            [varargout{1:nargout}] = setdiff(varargin{:});
+            % TODO?
+            varargout{1} = domain(varargout{1});
+        end
+        
+        function varargout = sprintf(varargin)
+            % This is required as built-in subsref does not know what to do with
+            % a DOMAIN object.
+            
+            varargin = domain2double(varargin{:});
+            
+            % Call built-in SPRINTF:
+            varargout{1:nargout} = sprintf(varargin{:});
+        end
+                   
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% STATIC METHODS:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    methods ( Access = public, Static = true )
+        
+        % Merge two domains:
+        newDom = merge(varargin)
+        
+        function varargin = toDouble(varargin)
+            % Cast DOMAIN to DOUBLE:
+            for k = 1:nargin
+                if ( isa(varargin{k}, 'domain') )
+                    varargin{k} = double(varargin{k});
+                end
+            end
+        end
+        
+    end
+    
+end

--- a/@domain/eye.m
+++ b/@domain/eye.m
@@ -1,0 +1,10 @@
+function I = eye(d)
+%EYE       Identity operator.
+%   This function is deprecated. Use OPERATORBLOCK.EYE.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+I = linop( operatorBlock.eye(double(d)) );
+
+end

--- a/@domain/feval.m
+++ b/@domain/feval.m
@@ -1,0 +1,10 @@
+function F = feval(d, loc, varargin)
+%FEVAL     Evaluation functional.
+%   This function is deprecated. Use FUNCTIONALBLOCK.FEVAL.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+F = linop( functionalBlock.feval(loc, double(d), varargin{:}) );
+
+end

--- a/@domain/fred.m
+++ b/@domain/fred.m
@@ -1,0 +1,10 @@
+function F = fred(k, d, varargin)
+%FRED      Fredholm integral operator.
+%   This function is deprecated. Use OPERATORBLOCK.FRED.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+F = linop( operatorBlock.fred(k, double(d), varargin{:}) );
+
+end

--- a/@domain/interp1.m
+++ b/@domain/interp1.m
@@ -1,0 +1,45 @@
+function p = interp1(x, y, method, dom)
+%INTERP1   CHEBFUN polynomial interpolant at any distribution of points.
+%   P = INTERP1(X, Y, D), where X and Y are vectors, returns the CHEBFUN P
+%   defined on the domain D([1, end]) corresponding to the polynomial
+%   interpolant through the data Y(j) at points X(j).
+%
+%   If Y is a matrix with more than one column then then Y(:,j) is taken as the
+%   value to be matched at X(j) and P is an array-valued CHEBFUN with each
+%   column corresponding to the appropriate interpolant.
+%
+%   EXAMPLE: The following commands plot the interpolant in 11 equispaced points
+%   on [-1, 1] through the famous Runge function:
+%       d = domain(-1, 1);
+%       ff = @(x) 1./(1+25*x.^2);
+%       x = linspace(d(1), d(2), 11);
+%       p = interp1(x, ff(x), d)
+%       f = chebfun(ff, d);
+%       plot(f, 'k', p, 'r-'), hold on, plot(x, ff(x), 'r.'), grid on
+%
+%   P = CHEBFUN.INTERP1(X, Y, METHOD, D) specifies alternate interpolation
+%   methods. The default is as described above. (Use an empty matrix [] to
+%   specify the default.) Available methods are:
+%       'linear'   - linear interpolation
+%       'spline'   - piecewise cubic spline interpolation (SPLINE)
+%       'pchip'    - shape-preserving piecewise cubic interpolation
+%       'cubic'    - same as 'pchip'
+%       'poly'     - polynomial interpolation, as described above
+%
+% See also SPLINE, PCHIP.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+if ( nargin == 3 )
+    dom = method;
+    method = [];
+end
+
+if ( ~isnumeric(y) )
+    y = feval(y, x);
+end
+
+p = chebfun.interp1(x, y, method, double(dom));
+
+end

--- a/@domain/merge.m
+++ b/@domain/merge.m
@@ -1,0 +1,69 @@
+function newDom = merge(varargin)
+%MERGE    Merge breakpoints (with a tolerance).
+%   MERGE(DOM1, DOM2, ..., DOMN, TOL) merges the breakpoints of the domains
+%   DOM1, ..., DOMN to a tolerance TOL, where DOM1, ..., DOMN are sorted vectors
+%   of real numbers. If the domains are not compatible, i.e.. the first and
+%   final entry of each DOM differ by more than TOL, then an error is returned.
+%
+%   MERGE(DOM1, DOM2, ..., DOMN) uses a tolerance of the largest magnitude entry
+%   in DOM1, ..., DOMN scaled by 10*eps.
+%
+%   MERGE() always returns an array of doubles, even if the inputs contain
+%   DOMAIN objects.
+%
+% See also WHICHDOMAIN, TWEAKDOMAIN, DOMAINCHECK.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Relabel the input variable:
+doms = varargin;
+% Make sure we have doubles, not domains:
+doms = cellfun(@(dom) double(dom), doms, 'UniformOutput', false);
+
+% Ignore empties:
+doms(cellfun(@isempty, doms)) = [];
+
+% Initialise newDom:
+newDom = [];
+
+% Choose a tolerance:
+if ( isscalar(varargin{end}) )
+    % One is given:
+    tol = varargin{end};
+    doms(end) = [];
+else
+    % 100*eps*hscale:
+    hscales = cellfun(@(d) norm(d, inf), doms);
+    hscales(isinf(hscales)) = 1;
+    tol = 100*eps*max(hscales);
+end
+% Check to see if the domains are compatible:
+ends = cellfun(@(dom) dom([1 end]), doms, 'UniformOutput', false);
+diffEnds = cell2mat(ends.') - repmat(ends{1}, numel(doms), 1);
+if ( any(diffEnds(:) > tol) )
+    error('CHEBFUN:DOMAIN:merge:incompat', 'Incompatible domains.');
+end
+
+j = 1;
+while ( ~isempty(doms) )
+    % Find the minimum remaining domain entry:
+    newDom(j) = min(cellfun(@min, doms)); %#ok<AGROW>
+    for k = numel(doms):-1:1
+        % Remove -inf
+        doms{k}(isinf(doms{k}) & doms{k} < 0) = [];
+        % Remove subsequent domains less than tol away:
+        doms{k}(doms{k} < newDom(j) + tol) = [];
+        if ( isempty(doms{k}) )
+            doms(k) = []; % Discard if this domain is now empty.
+        end
+        if ( isinf(newDom(j)) && newDom(j) > 0 )
+            % Stop if we get to +inf
+            doms = [];
+            break
+        end
+    end
+    j = j + 1;
+end 
+
+end

--- a/@domain/ode113.m
+++ b/@domain/ode113.m
@@ -1,0 +1,17 @@
+function varargout = ode113(varargin)
+%ODE113   Solve stiff differential equations and DAEs. Output a CHEBFUN.
+%   
+% This syntax is deprecated. Please use chebfun.ode113(...) instead.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+warning('CHEBFUN:DOMAIN:ode113:deprecated', ...
+    ['Usage of ODE113 via the @DOMAIN class is deprecated and may be ', ...
+    'removed from future releases. Please use chebfun.ode113(...) instead.']);
+
+varargin = domain.toDouble(varargin{:});
+
+varargout{1:nargout} = chebfun.ode113(varargin{:});
+
+end

--- a/@domain/ode15s.m
+++ b/@domain/ode15s.m
@@ -1,0 +1,17 @@
+function varargout = ode15s(varargin)
+%ODE15s   Solve stiff differential equations and DAEs. Output a CHEBFUN.
+%   
+% This syntax is deprecated. Please use chebfun.ode15s(...) instead.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+warning('CHEBFUN:DOMAIN:ode15s:deprecated', ...
+    ['Usage of ODE15S via the @DOMAIN class is deprecated and may be ', ...
+    'removed from future releases. Please use chebfun.ode15s(...) instead.']);
+
+varargin = domain.toDouble(varargin{:});
+
+varargout{1:nargout} = chebfun.ode15s(varargin{:});
+
+end

--- a/@domain/ode45.m
+++ b/@domain/ode45.m
@@ -1,0 +1,17 @@
+function varargout = ode45(varargin)
+%ODE45   Solve non-stiff ODEs. Output a CHEBFUN.
+%   
+% This syntax is deprecated. Please use chebfun.ode45(...) instead.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+warning('CHEBFUN:DOMAIN:ode45:deprecated', ...
+    ['Usage of ODE45 via the @DOMAIN class is deprecated and may be ', ...
+    'removed from future releases. Please use chebfun.ode45(...) instead.']);
+
+varargin = domain.toDouble(varargin{:});
+
+varargout{1:nargout} = chebfun.ode45(varargin{:});
+
+end

--- a/@domain/poly.m
+++ b/@domain/poly.m
@@ -1,0 +1,65 @@
+function f = poly(v, d)
+%POLY   Convert roots to CHEBFUN.
+%   POLY(V, D), when V is a column vector and D is a domain, returns a CHEBFUN
+%   of degree length(V) and domain D whose roots are the elements of V.
+%
+% Example (a nonstandard way to construct chebpoly(100)):
+%   T100 = poly(chebpts(100,1),domain(-1,1)); T100 = T100/T100(1);
+%
+% See also CHEBFUN/POLY.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Deal with array input:
+if ( min(size(v)) > 1 )
+    f = cell(1, size(v, 2));
+    for k = 1:size(v, 2)
+        f{k} = poly(v(:,k), d);
+    end
+    f = horzcat(f{:});
+    return
+end
+
+d = double(d);
+N = length(v);
+
+% Remove infs, and return NaN if NaN present:
+v = v(~isinf(v));
+if ( any(isnan(v)) )
+    f = chebfun(NaN, d);
+    return
+end
+
+% Return empty CHEBFUN if v is empty:
+if ( N == 0 )
+    f = chebfun();
+    return
+end
+
+% Leja ordering:
+[ignored, j] = max(abs(v));
+z = v(j);
+v(j) = [];
+for k = 1:(N-1)
+    P = zeros(N - k, 1);
+    for l = 1:(N-k)
+        P(l) = prod(z - v(l));
+    end
+    [ignored, j] = max(abs(P));
+    z(k+1) = v(j);
+    v(j) = [];
+end
+v = z;
+
+% Evaluate at Chebyshev points:
+x = chebpts(N+1, d);
+p = ones(N+1, 1);
+for k = 1:N
+    p = p.*(x - v(k));
+end
+
+% Contruct the CHEBFUN:
+f = chebfun(p, d, 'tech', @chebtech2);
+
+end

--- a/@domain/polyfit.m
+++ b/@domain/polyfit.m
@@ -1,0 +1,52 @@
+function f = polyfit(x, y, n, d)
+%POLYFIT   Polyfit discrete data and return a CHEBFUN object.
+%   F = POLYFIT(X, Y, N, D), where D is a DOMAIN object, returns a CHEBFUN F on
+%   the domain D([1, end]) which corresponds to the polynomial of degree N that
+%   fits the data (X, Y) in the least-squares sense. X should be a real-valued
+%   column vector and Y should be a matrix with size(Y,1) = size(X,1).
+%
+%   Note DOMAIN/POLYFIT does not not support more than one output argument in
+%   the way that MATLAB/POLYFIT does.
+%
+% See also CHEBFUN/POLYFIT.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Convert domain to a double:
+d = double(d);
+d = d([1, end]);
+
+% Align dimensions:
+if ( size(x, 2) > 1 )
+    if ( size(x, 1) > 1 )
+        error('CHEBFUN:DOMAIN:polyfit:xIn', ...
+            'X should be a real-valued column vector');
+    end
+    x = x.';
+end
+if ( size(y, 1) ~= size(x, 1) )
+    if ( size(y, 2) ~= size(x, 1) )
+        error('CHEBFUN:DOMAIN:polyfit:xIn', ...
+            'X and Y vectors must be the same size.');
+    end
+    y = y.';
+end
+
+% Make Chebyshev-Vandermonde matrix:
+% The code below is a faster version of 
+%       T = chebpoly(0:n, d); Tx = feval(T, x);
+m = numel(x)-1;
+Tx = zeros( m+1, n+1); 
+Tx(:,1) = ones(m+1,1);
+x_map = 2*(x-d(1))/(d(2)-d(1)) - 1;
+Tx(:,2) = x_map;
+for k = 2:n
+    Tx(:,k+1) = 2*x_map.*Tx(:,k) - Tx(:,k-1);
+end
+% Solve for coefficients (least squares)
+c = Tx\y;
+% Construct Chebfun:
+f = chebfun(c, d, 'coeffs');
+
+end

--- a/@domain/sum.m
+++ b/@domain/sum.m
@@ -1,0 +1,10 @@
+function S = sum(d)
+%SUM       Integration functional.
+%   This function is deprecated. Use FUNCTIONALBLOCK.SUM.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+S = linop( functionalBlock.sum(double(d)) );
+
+end

--- a/@domain/volt.m
+++ b/@domain/volt.m
@@ -1,0 +1,10 @@
+function V = volt(k, d, varargin)
+%VOLT      Volterra integral operator.
+%   This function is deprecated. Use OPERATORBLOCK.VOLT.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+V = linop( operatorBlock.volt(k, double(d), varargin{:}) );
+
+end

--- a/@domain/zeros.m
+++ b/@domain/zeros.m
@@ -1,0 +1,10 @@
+function Z = zeros(d)
+%ZEROS     Zero operator.
+%   This function is deprecated. Use OPERATORBLOCK.ZEROS.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+Z = linop( operatorBlock.zeros(double(d)) );
+
+end

--- a/domain.m
+++ b/domain.m
@@ -1,7 +1,0 @@
-function out = domain(varargin)
-%DOMAIN  fake constructor for a fake DOMAIN class.
-  for i=1:nargin
-    varargin{i} = double(varargin{i});
-  end
-  out = horzcat(varargin{:});
-end


### PR DESCRIPTION
In #18 you mentioned that the domain class might need to come back. We do need the `@domain/merge` function from these deleted files in `chebop`. I left your commit alone where you removed the inheritance of double in` @domain`, so technically the `domain` class is unusable, but from what I can tell, I only think we need the `@domain/merge.m` method, and this particular method doesn't even seem to be intimately tied to the classdef. I.e. you can call it like so

```
octave> domain.merge([1, 3], [1, 2, 3])
ans =

   1   2   3

```

So I reverted the commit where you deleted the entire classdef. The revert also doesn't seem to cause any new method resolution problems in `chebfun`, so I think it's safe to bring it back. Although I didn't check this last part extensively.

I also turned vectorize off by default in `chebop`. I couldn't tell exactly what the vectorized code was doing, it was a bit of a pain to debug. Maybe we can revert this later.