### PR TITLE
Disable tests that crash that Octave interpreter.

### DIFF
--- a/tests/adchebfun/test_ellipj.m
+++ b/tests/adchebfun/test_ellipj.m
@@ -2,6 +2,12 @@
 
 function pass = test_ellipj
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
+
 % List of airy functions to test, with different inputs
 ellipj075 = @(f) ellipj(f, 0.75);
 ellipj1 = @(f) ellipj(f, 1);

--- a/tests/chebfun/test_bvp4c.m
+++ b/tests/chebfun/test_bvp4c.m
@@ -1,8 +1,7 @@
 function pass = test_bvp4c(pref)
 
 if is_octave()
-  disp('Skipping these tests on Octave: no bvpinit yet?')
-  pass(1) = true;
+  error('Skipping these tests on Octave: no bvpinit yet?')
   return
 end
 

--- a/tests/chebfun/test_bvp5c.m
+++ b/tests/chebfun/test_bvp5c.m
@@ -1,8 +1,7 @@
 function pass = test_bvp5c(pref)
 
 if is_octave()
-  disp('Skipping these tests on Octave: no bvpinit yet?')
-  pass(1) = true;
+  error('Skipping these tests on Octave: no bvpinit yet?')
   return
 end
 

--- a/tests/chebfun/test_changeTech.m
+++ b/tests/chebfun/test_changeTech.m
@@ -1,10 +1,9 @@
 function pass = test_changeTech(pref)
 % Test CHEBFUN/CHANGETECH.
 
-if is_octave()
-  disp('Skipping these tests on Octave: need inferior class support(?)')
-  pass(1) = true;
-  return
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
 end
 
 if ( nargin == 0 )

--- a/tests/chebfun/test_constructor_inputs.m
+++ b/tests/chebfun/test_constructor_inputs.m
@@ -1,5 +1,11 @@
 function pass = test_constructor_inputs(pref)
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
+
 if ( nargin == 0 )
     pref = chebfunpref();
 end

--- a/tests/chebfun/test_constructor_inputs_periodic.m
+++ b/tests/chebfun/test_constructor_inputs_periodic.m
@@ -1,5 +1,10 @@
 function pass = test_constructor_inputs_periodic(pref)
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin == 0 )
     pref = chebfunpref();
 end

--- a/tests/chebfun/test_trigremez.m
+++ b/tests/chebfun/test_trigremez.m
@@ -1,6 +1,11 @@
 % Test for trigremez.m.
 function pass = test_trigremez(pref)
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 )
     pref = chebfunpref();
 end

--- a/tests/chebfun/test_truncate.m
+++ b/tests/chebfun/test_truncate.m
@@ -1,5 +1,10 @@
 function pass = test_truncate(pref)
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin == 0 )
     pref = chebfunpref();
 end

--- a/tests/chebfun2/test_norm.m
+++ b/tests/chebfun2/test_norm.m
@@ -1,5 +1,10 @@
 function pass = test_norm(pref)
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 )
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2/test_optimization.m
+++ b/tests/chebfun2/test_optimization.m
@@ -1,6 +1,11 @@
 function pass = test_optimization( pref ) 
 % Can we do global optimization?
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -1,6 +1,11 @@
 function pass = test_roots( )
 % Test the chebfun2/roots command.
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 tol = 1e-12;  % rank 1 curves
 tol2 = 1e-8;  % rank >1 curves, disjoint
 tol3 = 1e-4;  % rank >1 curves, noncircular

--- a/tests/chebfun2/test_roots_syntax.m
+++ b/tests/chebfun2/test_roots_syntax.m
@@ -1,6 +1,11 @@
 function pass = test_roots_syntax( pref ) 
 % Check the syntax to chebfun2/roots.
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end

--- a/tests/chebfun2v/test_roots01.m
+++ b/tests/chebfun2v/test_roots01.m
@@ -2,6 +2,11 @@ function pass = test_roots01( pref )
 % Check that the marching squares and Bezoutian agree with each other. 
 % Uncomment tests if harder tests should be executed.
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots02.m
+++ b/tests/chebfun2v/test_roots02.m
@@ -2,6 +2,11 @@ function pass = test_roots02( pref )
 % Check that the marching squares and Bezoutian agree with each other. 
 % Uncomment tests if harder tests should be executed.
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots04.m
+++ b/tests/chebfun2v/test_roots04.m
@@ -2,6 +2,11 @@ function pass = test_roots04( pref )
 % Check that the marching squares and Bezoutian agree with each other. 
 %%
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots05.m
+++ b/tests/chebfun2v/test_roots05.m
@@ -2,6 +2,11 @@ function pass = test_roots05( pref )
 % Check that the marching squares and Bezoutian agree with each other. 
 %%
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots06.m
+++ b/tests/chebfun2v/test_roots06.m
@@ -2,6 +2,11 @@ function pass = test_roots06( pref )
 % Check that the marching squares and Bezoutian agree with each other. 
 %%
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots07.m
+++ b/tests/chebfun2v/test_roots07.m
@@ -1,6 +1,11 @@
 function pass = test_roots07( pref ) 
 % Check that the marching squares and Bezoutian agree with each other. 
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots08.m
+++ b/tests/chebfun2v/test_roots08.m
@@ -1,6 +1,11 @@
 function pass = test_roots08( pref ) 
 % Check that the marching squares and Bezoutian agree with each other. 
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots09.m
+++ b/tests/chebfun2v/test_roots09.m
@@ -1,6 +1,11 @@
 function pass = test_roots09( pref ) 
 % Check that the marching squares and Bezoutian agree with each other. 
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebfun2v/test_roots_slow.m
+++ b/tests/chebfun2v/test_roots_slow.m
@@ -2,6 +2,11 @@ function pass = test_roots_slow( pref )
 % Check that the marching squares and Bezoutian agree with each other. 
 %%
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 

--- a/tests/chebmatrix/test_changeTech.m
+++ b/tests/chebmatrix/test_changeTech.m
@@ -1,6 +1,11 @@
 function pass = test_changeTech(pref)
 % Test CHEBMATRIX/CHANGETECH.
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin == 0 )
     pref = chebfunpref();
 end

--- a/tests/diskfun/test_roots.m
+++ b/tests/diskfun/test_roots.m
@@ -1,6 +1,11 @@
 function pass = test_roots( pref ) 
 % Check that roots works for a diskfun.
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end

--- a/tests/linop/test_mult_op.m
+++ b/tests/linop/test_mult_op.m
@@ -4,6 +4,12 @@ function pass = test_mult_op
 
 % TAD, 3 Feb 2014
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
+
 tol = 1e-14;
 
 d = [0,2];

--- a/tests/misc/test_minimax.m
+++ b/tests/misc/test_minimax.m
@@ -2,6 +2,11 @@
 
 function pass = test_minimax( pref )
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 % Generate a few random points to use as test values.
 seedRNG(6178);
 xx = 2 * rand(100, 1) - 1;

--- a/tests/spherefun/test_roots.m
+++ b/tests/spherefun/test_roots.m
@@ -1,6 +1,11 @@
 function pass = test_roots( pref ) 
 % Check that roots works for a spherefun.
 
+if (is_octave)
+    error("Disabling test on Octave, crashes the interpreter");
+    return
+end
+
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end


### PR DESCRIPTION
Also changed previous aborting tests to throw an error rather than return a pass/fail value.

With these changes, the full Octave test suite (running `chebtest()`) will work without interruption, and you can get an overview of the test diagnostics.